### PR TITLE
Blacklist magic pillars in OCW's Hall of Acumen

### DIFF
--- a/lightplacer/lpo.ini
+++ b/lightplacer/lpo.ini
@@ -152,6 +152,9 @@
 ; works without this option, so don't hide this behind a fomod step.
 QuickLight.esp
 
+; Obscure's College of Winterhold - Hall of Acumen
+0x08E765~OCW_Obscure's_CollegeofWinterhold.esp
+
 ; Obscure's College of Winterhold - Hall of Diligence
 ; The refs near these lights have been blacklisted for performance. 
 0x195F18~OCW_Obscure's_CollegeofWinterhold.esp

--- a/lightplacer/lpo/magic.json
+++ b/lightplacer/lpo/magic.json
@@ -86,6 +86,9 @@
   {
     "lights": [
       {
+        "blackList": [
+          "0x08E764~OCW_Obscure's_CollegeofWinterhold.esp"
+        ],
         "data": {
           "fade": 1.5,
           "flags": "IgnoreScale|NoExternalEmittance",
@@ -114,6 +117,11 @@
   {
     "lights": [
       {
+        "blackList": [
+          "0x08E76A~OCW_Obscure's_CollegeofWinterhold.esp",
+          "0x08E76B~OCW_Obscure's_CollegeofWinterhold.esp",
+          "0x08E76C~OCW_Obscure's_CollegeofWinterhold.esp"
+        ],
         "data": {
           "fade": 2.0,
           "flags": "IgnoreScale|NoExternalEmittance",


### PR DESCRIPTION
One of the cells added by Obscure's College of Winterhold, the Hall of Acumen, has four magic pillars placed inside it. They need to be blacklisted, otherwise the combined lights overpower the cell.